### PR TITLE
Шевырин Никита

### DIFF
--- a/homework 1/ReaderWriterLock/Extensions.cs
+++ b/homework 1/ReaderWriterLock/Extensions.cs
@@ -10,4 +10,14 @@ public static class Extensions
         foreach (var item in enumerable)
             action(item);
     }
+
+    public static void ForEach<T>(this IEnumerable<T> enumerable, Action<T, int> action)
+    {
+        var index = 0;
+        foreach (var item in enumerable)
+        {
+            action(item, index);
+            index++;
+        }
+    }
 }

--- a/homework 1/ReaderWriterLock/SharedReourceTests.cs
+++ b/homework 1/ReaderWriterLock/SharedReourceTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading;
 using NUnit.Framework;
@@ -13,23 +12,69 @@ public class SharedResourceTests
     private const int ReadersThreads = 1000;
     private SharedResourceBase _sharedResource;
 
+    private void RunThreads()
+    {
+        var countdown = new CountdownEvent(ReadersThreads + WritersThreads);
+        var startEvent = new ManualResetEventSlim();
+        
+        for (var i = 0; i < WritersThreads; i++)
+        {
+            var number = i;
+            var thread = new Thread(() =>
+            {
+                startEvent.Wait();
+                _sharedResource.Write($"Data {number}");
+                countdown.Signal();
+            });
+            thread.Start();
+        }
+
+        for (var i = 0; i < ReadersThreads; i++)
+        {
+            var thread = new Thread(() =>
+            {
+                startEvent.Wait();
+                var result = _sharedResource.Read();
+                Assert.That(result, Is.Ordered.Ascending);
+                result.ForEach(str =>
+                    ClassicAssert.IsTrue(str.Split(' ')[0] == "Data" && int.TryParse(str.Split(' ')[1], out _)));
+                countdown.Signal();
+            });
+            thread.Start();
+        }
+        
+        startEvent.Set();
+        countdown.Wait();
+    }
+
+    private void AssertResult()
+    {
+        ClassicAssert.AreEqual($"Data {WritersThreads-1}", _sharedResource.Read().Last());
+        ClassicAssert.AreEqual(_sharedResource.Count, WritersThreads);
+        var values = _sharedResource.Read();
+        Enumerable.Range(0, WritersThreads)
+            .Select(i => $"Data {i}")
+            .OrderBy(str => str)
+            .ForEach((str, i) => ClassicAssert.AreEqual(str, values[i]));
+    }
+
     [Test]
     public void TestConcurrentReadWrite()
     {
-        // Реализовать проверку конкурентной записи и чтения, где в конце должны проверить что данные последнего потока записаны
-        // Проверка должна быть многопоточной.
-        // Потоков чтения должно быть ReadersThreads, потоков записи должно быть WritersThreads
+        _sharedResource = new SharedResourceLock();
         
-        ClassicAssert.AreEqual($"Data {WritersThreads-1}", _sharedResource.Read());
+        RunThreads();
+        
+        AssertResult();
     }
     
     [Test]
     public void TestConcurrentReadWriteRwLock()
     {
-        // Реализовать проверку конкурентной записи и чтения, где в конце должны проверить что данные последнего потока записаны
-        // Проверка должна быть многопоточной
-        // Потоков чтения должно быть ReadersThreads, потоков записи должно быть WritersThreads
+        _sharedResource = new SharedResourceRwLock();
         
-        ClassicAssert.AreEqual($"Data {WritersThreads-1}", _sharedResource.Read());
+        RunThreads();
+        
+        AssertResult();
     }
 }

--- a/homework 1/ReaderWriterLock/SharedResourceBase.cs
+++ b/homework 1/ReaderWriterLock/SharedResourceBase.cs
@@ -1,10 +1,18 @@
+using System;
+using System.Collections.Generic;
+
 namespace ReaderWriterLock;
 
 public abstract class SharedResourceBase
 {
+    protected SortedSet<string> _sharedResource = new SortedSet<string>();
+    
     public abstract void Write(string data);
-    public abstract string Read();
-    public abstract long ComputeFactorial(int number);
+    public abstract string[] Read();
+    public abstract long ComputeFactorialRead(int number);
+    public abstract long ComputeFactorialWrite(int number);
+    
+    public int Count => _sharedResource.Count;
     
     protected long Factorial(int number)
     {

--- a/homework 1/ReaderWriterLock/SharedResourceLock.cs
+++ b/homework 1/ReaderWriterLock/SharedResourceLock.cs
@@ -1,19 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
 namespace ReaderWriterLock;
 
 public class SharedResourceLock : SharedResourceBase
 {
+    private readonly object _lock = new object();
+    
     public override void Write(string data)
     {
-        throw new System.NotImplementedException();
+        lock (_lock)
+        {
+            _sharedResource.Add(data);
+        }
     }
 
-    public override string Read()
+    public override string[] Read()
     {
-        throw new System.NotImplementedException();
+        lock (_lock)
+        {
+            return _sharedResource.ToArray();
+        }
     }
 
-    public override long ComputeFactorial(int number)
+    public override long ComputeFactorialRead(int number)
     {
-        throw new System.NotImplementedException();
+        lock (_lock)
+        {
+            return Factorial(number);
+        }
+    }
+
+    public override long ComputeFactorialWrite(int number)
+    {
+        lock (_lock)
+        {
+            return Factorial(number);
+        }
     }
 }

--- a/homework 1/ReaderWriterLock/SharedResourceRwLock.cs
+++ b/homework 1/ReaderWriterLock/SharedResourceRwLock.cs
@@ -1,19 +1,67 @@
+using System.Linq;
+using System.Threading;
+
 namespace ReaderWriterLock;
 
 public class SharedResourceRwLock : SharedResourceBase
 {
+    private readonly ReaderWriterLockSlim _rwLock = new ReaderWriterLockSlim();
+
+    ~SharedResourceRwLock()
+    {
+        _rwLock.Dispose();
+    }
+    
     public override void Write(string data)
     {
-        throw new System.NotImplementedException();
+        _rwLock.EnterWriteLock();
+        try
+        {
+            _sharedResource.Add(data);
+        }
+        finally
+        {
+            _rwLock.ExitWriteLock();
+        }
     }
 
-    public override string Read()
+    public override string[] Read()
     {
-        throw new System.NotImplementedException();
+        _rwLock.EnterReadLock();
+        try
+        {
+            return _sharedResource.ToArray();
+        }
+        finally
+        {
+            _rwLock.ExitReadLock();
+        }
     }
 
-    public override long ComputeFactorial(int number)
+    public override long ComputeFactorialRead(int number)
     {
-        throw new System.NotImplementedException();
+        _rwLock.EnterReadLock();
+        try
+        {
+            return Factorial(number);
+        }
+        finally
+        {
+            _rwLock.ExitReadLock();
+        }
+        
+    }
+
+    public override long ComputeFactorialWrite(int number)
+    {
+        _rwLock.EnterWriteLock();
+        try
+        {
+            return Factorial(number);
+        }
+        finally
+        {
+            _rwLock.ExitWriteLock();
+        }
     }
 }


### PR DESCRIPTION
Изменил у метода `Read()` возвращаемый тип на `string[]` для упрощения проверки валидности данных (да и не совсем понял изначальную задумку того как именно должен работать этот общий ресурс). Так же вместо метода `ComputeFactorial()` использовал два метода `ComputFactorialRead()` и `ComputeFactorialWrite()` для симуляции нагрузки в записывающих и читающих потоках по отдельности, правда различие между ними есть только в классе `SharedResourceRwLock`.